### PR TITLE
update to telegram-19.0.0.preview.2

### DIFF
--- a/Allowed.Telegram.Bot.Data/Allowed.Telegram.Bot.Data.csproj
+++ b/Allowed.Telegram.Bot.Data/Allowed.Telegram.Bot.Data.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Telegram.Bot" Version="18.0.0" />
+        <PackageReference Include="Telegram.Bot" Version="19.0.0-preview.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Allowed.Telegram.Bot.Sample/Controllers/TypedController.cs
+++ b/Allowed.Telegram.Bot.Sample/Controllers/TypedController.cs
@@ -2,6 +2,7 @@
 using Allowed.Telegram.Bot.Data.Controllers;
 using Allowed.Telegram.Bot.Models;
 using Telegram.Bot;
+using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 
 namespace Allowed.Telegram.Bot.Sample.Controllers;
@@ -12,24 +13,24 @@ public class TypedController : CommandController<int>
     [TypedCommand(MessageType.Photo)]
     public async Task Photo(MessageData data)
     {
-        await data.Client.SendPhotoAsync(data.Message.From!.Id, data.Message.Photo![0].FileId);
+        await data.Client.SendPhotoAsync(data.Message.From!.Id, new InputFileId( data.Message.Photo![0].FileId));
     }
 
     [TypedCommand(MessageType.Video)]
     public async Task Video(MessageData data)
     {
-        await data.Client.SendVideoAsync(data.Message.From!.Id, data.Message.Video!.FileId);
+        await data.Client.SendVideoAsync(data.Message.From!.Id, new InputFileId(data.Message.Video!.FileId));
     }
 
     [TypedCommand(MessageType.Audio)]
     public async Task Audio(MessageData data)
     {
-        await data.Client.SendAudioAsync(data.Message.From!.Id, data.Message.Audio!.FileId);
+        await data.Client.SendAudioAsync(data.Message.From!.Id, new InputFileId(data.Message.Audio!.FileId));
     }
 
     [TypedCommand(MessageType.ChatMembersAdded)]
     public async Task ChatMembersAdded(MessageData data)
     {
-        await data.Client.SendAudioAsync(data.Message.From!.Id, "Chat member added!");
+        await data.Client.SendAudioAsync(data.Message.From!.Id, new InputFileId("Chat member added!"));
     }
 }

--- a/Allowed.Telegram.Bot/Allowed.Telegram.Bot.csproj
+++ b/Allowed.Telegram.Bot/Allowed.Telegram.Bot.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Telegram.Bot" Version="18.0.0" />
+        <PackageReference Include="Telegram.Bot" Version="19.0.0-preview.2" />
         <PackageReference Include="Telegram.Bot.Extensions.Polling" Version="1.0.2" />
     </ItemGroup>
 

--- a/Allowed.Telegram.Bot/Managers/TelegramWebHookManager.cs
+++ b/Allowed.Telegram.Bot/Managers/TelegramWebHookManager.cs
@@ -41,9 +41,8 @@ public class TelegramWebHookManager : ITelegramManager
 
         if (TelegramWebHookOptions.DeleteOldHooks)
             await client.Client.DeleteWebhookAsync();
-        await client.Client.SetWebhookAsync(
-            webhookAddress,
-            allowedUpdates: Array.Empty<UpdateType>());
+
+        await client.Client.SetWebhookAsync(webhookAddress, allowedUpdates: Array.Empty<UpdateType>());
     }
 
     public virtual async Task Stop(IEnumerable<string> names)
@@ -51,18 +50,17 @@ public class TelegramWebHookManager : ITelegramManager
         foreach (var name in names) await Stop(name);
     }
 
-    public Task Stop(string name)
+    public async Task Stop(string name)
     {
         var client = ClientsCollection.Clients.SingleOrDefault(c => c.Options.Name == name);
         if (client == null)
         {
             Logger.LogWarning("Telegram bot has already been stopped!");
-            return Task.CompletedTask;
+            return;
         }
 
-        client.Client.DeleteWebhookAsync();
+        await client.Client.DeleteWebhookAsync();
         ClientsCollection.Clients.Remove(client);
-        return Task.CompletedTask;
     }
 
     public virtual async Task Start(IEnumerable<ClientItem> clients)


### PR DESCRIPTION
Hi @VodemSharp 
I will propose this PR to be released as pre-release NuGet. as long as stable release, we maybe need updated Bot API version.
currently, latest pre-release version which is supported by `telegram-19.0.0.preview.2` is **Bot API 6.4**

This PR tested in both Pool and Webhook mode.

This PR will close #4 as well.

thank you.